### PR TITLE
Clarify offset key

### DIFF
--- a/specs/pprox.json
+++ b/specs/pprox.json
@@ -19,12 +19,12 @@
                 },
                 "interval": {
                     "type": "array",
-                    "description": "beginning and end of the point process, in seconds",
+                    "description": "beginning and end of the point process, in seconds, relative to `offset`, if present",
                     "length": 2
                 },
                 "offset": {
                     "type": "number",
-                    "description": "offset, in seconds, added to event times"
+                    "description": "offset, in seconds, added to all times for this point process"
                 },
                 "marks": {
                     "description": "map of arrays that mark the events",

--- a/specs/pprox.md
+++ b/specs/pprox.md
@@ -51,6 +51,8 @@ A minimal point process looks like this:
 
 The `events` field and the `interval` field are REQUIRED. The `events` field MUST be an array of numerical values, in units of seconds. The `interval` field MUST be an array with exactly two elements, where the first element is the time at which the point process began and the second element is the time at which the point process ended, both in seconds. A point process MAY contain two optional fields: `offset` and `marks`. If present, `offset` MUST be a single numerical value that indicates a relative temporal offset, in seconds, for all the events. If present, `marks` MUST be an map containing one or more fields. Each field in `marks` MUST be an array that corresponds one-to-one with the `events` array. Any number of additional fields MAY be used to store metadata. Keys MUST be unique and MUST NOT conflict with any of the required or optional fields described above.
 
+Note that if the `offset` key is present, every time in that trial will be relative to this offset. Therefore, every single event in the `events` key should be in the closed interval defined by the `interval` key, whether or not `offset` is present.
+
 Let's consider some example use cases. First, extracellular spike times recorded in response to a presented stimulus. We code the stimulus identity using a
 [UUID](http://tools.ietf.org/html/rfc4122.html) and indicate the start and stop times of the stimulus with the `stimulus_on` and `stimulus_off` fields. We could also code the stimulus using a more human-readable name, but globally unique identifiers help to avoid confusion down the road. Because this is part of a larger experiment in which many stimuli were presented, we've also stored a relative offset time and an index for the trial.
 

--- a/specs/stimtrial.json
+++ b/specs/stimtrial.json
@@ -30,7 +30,7 @@
                                 "interval": {
                                     "type": "array",
                                     "length": 2,
-                                    "description": "the start and end time of the stimulus, in seconds"
+                                    "description": "the start and end time of the stimulus, in seconds, relative to `offset`, if present"
                                 }
                             },
                             "required": ["name", "interval"]


### PR DESCRIPTION
Not properly adding the offset key during normalization to stimtrial format was causing the drop in performance that I mentioned, so I'm taking this as a reminder to get it fixed in the spec